### PR TITLE
Payment validation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ composer.lock
 
 ### phpUnit
 phpunit.xml
+
+
+### ides
+.idea

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -923,7 +923,7 @@ class Payment
         $this->set($data);
         $this->setId($data['InvId']);
 
-        $this->valid = $data['SignatureValue'] === $this->auth->getSignatureHash(
+        $this->valid = strcasecmp($data['SignatureValue'], $this->auth->getSignatureHash(
             '{os}:{ii}:{pp}{:cp}',
             [
                 'os' => $data['OutSum'],
@@ -931,7 +931,7 @@ class Payment
                 'pp' => $this->auth->{'get' . $passwordType . 'Password'}(),
                 'cp' => $this->getCustomParamsString(),
             ]
-        );
+        )) === 0;
 
         if ($this->valid && $strict) {
             try {

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -313,7 +313,7 @@ class PaymentTest extends TestCase
     public function set_expiration_date_as_string_in_custom_format()
     {
         $payment = $this->createPayment()->setExpirationDate('21.01.2016 20:10:43', 'd.m.Y H:i:s');
-        $this->assertEquals($payment->getExpirationDate()->format('c'), '2016-01-21T20:10:43+00:00');
+        $this->assertEquals($payment->getExpirationDate()->format('d.m.Y H:i:s'), '21.01.2016 20:10:43');
     }
 
     /**


### PR DESCRIPTION
ROBOKASSA sends SignatureValue as an uppercased string. This library doesn't handle such ones.